### PR TITLE
Added python-requests minimum requirement of version 2.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests>=2.4.3
 websocket-client
 future


### PR DESCRIPTION
for POST json data support (https://pypi.python.org/pypi/requests/2.4.3)

This refers to #39 