### PR TITLE
Switch to API Level 12

### DIFF
--- a/homematicip/HomeMaticIPObject.py
+++ b/homematicip/HomeMaticIPObject.py
@@ -14,7 +14,7 @@ class HomeMaticIPObject(object):
     _restCallRequestCounter = 3 #the homematic ip cloud tends to time out. retry the call X times.
     _restCallTimout = 3
     def __init__(self):
-        self.headers = {'content-type': 'application/json', 'accept': 'application/json', 'VERSION': '10',
+        self.headers = {'content-type': 'application/json', 'accept': 'application/json', 'VERSION': '12',
                         'AUTHTOKEN': homematicip.get_auth_token(), 'CLIENTAUTH' : homematicip.get_clientauth_token()}
 
     def _restCall(self, path, body = None):

--- a/homematicip/auth.py
+++ b/homematicip/auth.py
@@ -13,7 +13,7 @@ class Auth(object):
     pin = None
     def __init__(self):
         self.uuid = str(uuid.uuid4())
-        self.headers = {'content-type': 'application/json', 'accept': 'application/json', 'VERSION': '10', 'CLIENTAUTH' : homematicip.get_clientauth_token() }
+        self.headers = {'content-type': 'application/json', 'accept': 'application/json', 'VERSION': '12', 'CLIENTAUTH' : homematicip.get_clientauth_token() }
 
     def connectionRequest(self, access_point, devicename = "homematicip-python"):
         data = {"deviceId": self.uuid, "deviceName": devicename, "sgtin": access_point}

--- a/homematicip/group.py
+++ b/homematicip/group.py
@@ -224,11 +224,9 @@ class HeatingChangeoverGroup(Group):
     def from_json(self, js, devices):
         super(HeatingChangeoverGroup, self).from_json(js, devices)
         self.on = js["on"]
-        self.dimLevel = js["dimLevel"]
 
     def __unicode__(self):
-        return u"{} on({}) dimLevel({})".format(super(HeatingChangeoverGroup, self).__unicode__(),
-                                                self.on, self.dimLevel)
+        return u"{} on({})".format(super(HeatingChangeoverGroup, self).__unicode__(), self.on)
 
 #at the moment it doesn't look like this class has any special properties/functions
 #keep it as a placeholder in the meantime
@@ -425,11 +423,9 @@ class HeatingDehumidifierGroup(Group):
     def from_json(self, js, devices):
         super(HeatingDehumidifierGroup, self).from_json(js, devices)
         self.on = js["on"]
-        self.dimLevel = js["dimLevel"]
 
     def __unicode__(self):
-        return u"{}: on({}) dimLevel({}) ".format(super(HeatingDehumidifierGroup, self).__unicode__(),
-                                                self.on, self.dimLevel)
+        return u"{}: on({})".format(super(HeatingDehumidifierGroup, self).__unicode__(), self.on)
 
 class HeatingCoolingDemandGroup(Group):
     on = None
@@ -459,13 +455,12 @@ class HeatingCoolingDemandBoilerGroup(Group):
     def from_json(self, js, devices):
         super(HeatingCoolingDemandBoilerGroup, self).from_json(js, devices)
         self.on = js["on"]
-        self.dimLevel = js["dimLevel"]
         self.boilerLeadTime = js["boilerLeadTime"]
         self.boilerFollowUpTime = js["boilerFollowUpTime"]
 
     def __unicode__(self):
-        return u"{}: on({}) dimLevel({}) boilerFollowUpTime({}) boilerLeadTime({})".format(super(HeatingCoolingDemandBoilerGroup, self).__unicode__(),
-                                                self.on, self.dimLevel, self.boilerFollowUpTime, self.boilerLeadTime)
+        return u"{}: on({}) boilerFollowUpTime({}) boilerLeadTime({})".format(super(HeatingCoolingDemandBoilerGroup, self).__unicode__(),
+                                                self.on, self.boilerFollowUpTime, self.boilerLeadTime)
 
 class HeatingCoolingDemandPumpGroup(Group):
     pumpProtectionDuration = None
@@ -478,15 +473,19 @@ class HeatingCoolingDemandPumpGroup(Group):
     def from_json(self, js, devices):
         super(HeatingCoolingDemandPumpGroup, self).from_json(js, devices)
         self.on = js["on"]
-        self.dimLevel = js["dimLevel"]
         self.pumpProtectionSwitchingInterval = js["pumpProtectionSwitchingInterval"]
         self.pumpProtectionDuration = js["pumpProtectionDuration"]
         self.pumpFollowUpTime = js["pumpFollowUpTime"]
         self.pumpLeadTime = js["pumpLeadTime"]
 
     def __unicode__(self):
-        return u"{}: on({}) dimLevel({}) pumpProtectionDuration({}) pumpProtectionSwitchingInterval({}) pumpFollowUpTime({}) pumpLeadTime({})".format(super(HeatingCoolingDemandPumpGroup, self).__unicode__(),
-                                                self.on, self.dimLevel, self.pumpProtectionDuration, self.pumpProtectionSwitchingInterval, self.pumpFollowUpTime, self.pumpLeadTime)
+        return u"{}: on({}) pumpProtectionDuration({}) pumpProtectionSwitchingInterval({}) pumpFollowUpTime({}) " \
+               u"pumpLeadTime({})".format(super(HeatingCoolingDemandPumpGroup, self).__unicode__(),
+                                          self.on, self.pumpProtectionDuration,
+                                          self.pumpProtectionSwitchingInterval,
+                                          self.pumpFollowUpTime, self.pumpLeadTime)
+
+
 class TimeProfilePeriod(HomeMaticIPObject.HomeMaticIPObject):
     weekdays = []
     hour = 0


### PR DESCRIPTION
Switched to API Level 12 which is the minimum supported API level after upgrading to Homematic IP iOS-App Version 1.8.0.