### PR TITLE
Remove error logger in _ws_loop

### DIFF
--- a/homematicip/aio/connection.py
+++ b/homematicip/aio/connection.py
@@ -154,6 +154,5 @@ class AsyncConnection(BaseConnection):
         except Exception as err:
             logger.exception(err)
         finally:
-            on_error()
             await self.close_websocket_connection()
             raise HmipConnectionError


### PR DESCRIPTION
Hi, the on_error function is actually called without arguments but should have some. I would suggest to remove the error logging.