### PR TITLE
Fix enum backward compatitibility py34

### DIFF
--- a/homematicip/base/enums.py
+++ b/homematicip/base/enums.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from enum import auto, Enum
+from aenum import auto, Enum
 
 
 class AutoNameEnum(Enum):

--- a/homematicip/base/enums.py
+++ b/homematicip/base/enums.py
@@ -9,6 +9,13 @@ class AutoNameEnum(Enum):
     def __str__(self):
         return self.value
 
+    @classmethod
+    def from_str(cls, text):
+        if text is None:
+            return None
+        return cls(text)
+
+
 class AcousticAlarmTiming(AutoNameEnum):
     PERMANENT = auto()
     THREE_MINUTES = auto()

--- a/homematicip/device.py
+++ b/homematicip/device.py
@@ -160,7 +160,7 @@ class HeatingThermostat(OperationLockableDevice):
         if c:
             self.temperatureOffset = c["temperatureOffset"]
             self.valvePosition = c["valvePosition"]
-            self.valveState = ValveState(c["valveState"])
+            self.valveState = ValveState.from_str(c["valveState"])
             self.setPointTemperature = c["setPointTemperature"]
 
     def __str__(self):
@@ -181,8 +181,7 @@ class ShutterContact(SabotageDevice):
         super().from_json(js)
         c = get_functional_channel("SHUTTER_CONTACT_CHANNEL", js)
         if c:
-            if c["windowState"]:
-                self.windowState = WindowState(c["windowState"])
+            self.windowState = WindowState.from_str(c["windowState"])
             self.eventDelay = c["eventDelay"]
 
     def __str__(self):
@@ -199,7 +198,7 @@ class RotaryHandleSensor(SabotageDevice):
         super().from_json(js)
         c = get_functional_channel("ROTARY_HANDLE_CHANNEL", js)
         if c:
-            self.windowState = WindowState(c["windowState"])
+            self.windowState = WindowState.from_str(c["windowState"])
             self.eventDelay = c["eventDelay"]
 
     def __str__(self):
@@ -260,7 +259,7 @@ class TemperatureHumiditySensorDisplay(Device):
         c = get_functional_channel("WALL_MOUNTED_THERMOSTAT_PRO_CHANNEL", js)
         if c:
             self.temperatureOffset = c["temperatureOffset"]
-            self.display = ClimateControlDisplay(c["display"])
+            self.display = ClimateControlDisplay.from_str(c["display"])
             self.actualTemperature = c["actualTemperature"]
             self.humidity = c["humidity"]
             self.setPointTemperature = c["setPointTemperature"]
@@ -285,7 +284,7 @@ class WallMountedThermostatPro(TemperatureHumiditySensorDisplay,
         c = get_functional_channel("WALL_MOUNTED_THERMOSTAT_PRO_CHANNEL", js)
         if c:
             self.temperatureOffset = c["temperatureOffset"]
-            self.display = ClimateControlDisplay(c["display"])
+            self.display = ClimateControlDisplay.from_str(c["display"])
             self.actualTemperature = c["actualTemperature"]
             self.humidity = c["humidity"]
             self.setPointTemperature = c["setPointTemperature"]
@@ -323,7 +322,7 @@ class FloorTerminalBlock6(Device):
         if c:
             self.unreach = c["unreach"]
             self.globalPumpControl = c["globalPumpControl"]
-            self.heatingValveType = HeatingValveType(c["heatingValveType"])
+            self.heatingValveType = HeatingValveType.from_str(c["heatingValveType"])
 
     def __str__(self):
         return "{}: globalPumpControl({})".format(super().__str__(),
@@ -674,12 +673,12 @@ class WaterSensor(Device):
 
         c = get_functional_channel("WATER_SENSOR_CHANNEL", js)
         if c:
-            self.acousticAlarmSignal = AcousticAlarmSignal(c["acousticAlarmSignal"])
-            self.acousticAlarmTiming = AcousticAlarmTiming(c["acousticAlarmTiming"])
-            self.acousticWaterAlarmTrigger = WaterAlarmTrigger(c["acousticWaterAlarmTrigger"])
-            self.inAppWaterAlarmTrigger = WaterAlarmTrigger(c["inAppWaterAlarmTrigger"])
+            self.acousticAlarmSignal = AcousticAlarmSignal.from_str(c["acousticAlarmSignal"])
+            self.acousticAlarmTiming = AcousticAlarmTiming.from_str(c["acousticAlarmTiming"])
+            self.acousticWaterAlarmTrigger = WaterAlarmTrigger.from_str(c["acousticWaterAlarmTrigger"])
+            self.inAppWaterAlarmTrigger = WaterAlarmTrigger.from_str(c["inAppWaterAlarmTrigger"])
             self.moistureDetected = c["moistureDetected"]
-            self.sirenWaterAlarmTrigger = WaterAlarmTrigger(c["sirenWaterAlarmTrigger"])
+            self.sirenWaterAlarmTrigger = WaterAlarmTrigger.from_str(c["sirenWaterAlarmTrigger"])
             self.waterlevelDetected = c["waterlevelDetected"]
 
     def __str__(self):

--- a/homematicip/device.py
+++ b/homematicip/device.py
@@ -181,7 +181,8 @@ class ShutterContact(SabotageDevice):
         super().from_json(js)
         c = get_functional_channel("SHUTTER_CONTACT_CHANNEL", js)
         if c:
-            self.windowState = WindowState(c["windowState"])
+            if c["windowState"]:
+                self.windowState = WindowState(c["windowState"])
             self.eventDelay = c["eventDelay"]
 
     def __str__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ websocket-client
 async_timeout
 websockets
 aiohttp
+aenum

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ pytest-cov
 pytest-localserver
 pytest-xdist
 versioneer
+aenum


### PR DESCRIPTION
Hi, I bumped into a backward compatibility issue with enum for py34 which homeassistent is asking for. 

- Would it be OK for you to change to `aenum`?
https://codereview.stackexchange.com/questions/177309/reimplementing-pythons-enum-auto-for-compatibility

- The windowState is sometime `None` for me with breaks the from_json function.
- Please, can you create a release with this fixes?

Thanks Mattias