### PR TITLE
Improve async testing.

### DIFF
--- a/homematicip/aio/auth.py
+++ b/homematicip/aio/auth.py
@@ -1,12 +1,10 @@
-import asyncio
 import json
-import uuid
 import logging
+import uuid
 
 from homematicip.aio.connection import AsyncConnection
 from homematicip.auth import Auth
-from homematicip.base.base_connection import BaseConnection, HmipWrongHttpStatusError, \
-    ATTR_AUTH_TOKEN, ATTR_CLIENT_AUTH, HmipConnectionError
+from homematicip.base.base_connection import HmipWrongHttpStatusError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -14,7 +12,15 @@ LOGGER = logging.getLogger(__name__)
 class AsyncAuthConnection(AsyncConnection):
     def __init__(self, loop, session=None):
         super().__init__(loop, session)
-        self.headers = {'content-type': 'application/json', 'accept': 'application/json', 'VERSION': '12', 'CLIENTAUTH' : self.clientauth_token }
+        self.headers = {
+            "content-type": "application/json",
+            "accept": "application/json",
+            "VERSION": "12",
+            "CLIENTAUTH": self.clientauth_token,
+        }
+
+
+# todo: make the overridden methods match signature and return types of the overridden class.
 
 
 class AsyncAuth(Auth):
@@ -23,36 +29,48 @@ class AsyncAuth(Auth):
     def __init__(self, loop, websession=None):
         self.uuid = str(uuid.uuid4())
         self.pin = None
-        self._connection=AsyncAuthConnection(loop, websession)
+        self._connection = AsyncAuthConnection(loop, websession)
 
-    async def init(self, access_point_id, lookup=True, lookup_url = None):
+    async def init(self, access_point_id, lookup=True, lookup_url=None):
         self.accesspoint = access_point_id
         if lookup_url:
             await self._connection.init(access_point_id, lookup, lookup_url)
         else:
             await self._connection.init(access_point_id, lookup)
 
-    async def connectionRequest(self, devicename = "homematicip-async"):
-        data = {"deviceId": self.uuid, "deviceName": devicename, "sgtin": self.accesspoint}
-        if self.pin != None:
+    async def connectionRequest(self, devicename="homematicip-async"):
+        data = {
+            "deviceId": self.uuid,
+            "deviceName": devicename,
+            "sgtin": self.accesspoint,
+        }
+        if self.pin is not None:
             self._connection.headers["PIN"] = self.pin
-        json_state = await self._connection.api_call('auth/connectionRequest', json.dumps(data))
+        json_state = await self._connection.api_call(
+            "auth/connectionRequest", json.dumps(data)
+        )
         return json_state
 
     async def isRequestAcknowledged(self):
         data = {"deviceId": self.uuid}
         try:
-            await self._connection.api_call('auth/isRequestAcknowledged', json.dumps(data))
+            await self._connection.api_call(
+                "auth/isRequestAcknowledged", json.dumps(data)
+            )
             return True
         except HmipWrongHttpStatusError:
             return False
 
     async def requestAuthToken(self):
         data = {"deviceId": self.uuid}
-        json_state = await self._connection.api_call('auth/requestAuthToken', json.dumps(data))
+        json_state = await self._connection.api_call(
+            "auth/requestAuthToken", json.dumps(data)
+        )
         return json_state["authToken"]
 
     async def confirmAuthToken(self, authToken):
         data = {"deviceId": self.uuid, "authToken": authToken}
-        json_state = await self._connection.api_call('auth/confirmAuthToken', json.dumps(data))
+        json_state = await self._connection.api_call(
+            "auth/confirmAuthToken", json.dumps(data)
+        )
         return json_state["clientId"]

--- a/tests/aio_tests/fake_hmip_server.py
+++ b/tests/aio_tests/fake_hmip_server.py
@@ -1,10 +1,10 @@
 import asyncio
+import logging
 import pathlib
 import socket
 import ssl
 
 import aiohttp
-import logging
 from aiohttp import web
 from aiohttp.resolver import DefaultResolver
 from aiohttp.test_utils import unused_port

--- a/tests/aio_tests/notest_connection_async.py
+++ b/tests/aio_tests/notest_connection_async.py
@@ -2,13 +2,13 @@ import asyncio
 
 import aiohttp
 import pytest
+from tests.fake_hmip_server import FakeLookupHmip, FakeConnectionHmip, FakeWebsocketHmip
+from tests.helpers import mockreturn
 
 from homematicip.aio.connection import AsyncConnection
 from homematicip.base.base_connection import HmipWrongHttpStatusError, \
     HmipConnectionError, \
     ATTR_AUTH_TOKEN, ATTR_CLIENT_AUTH, HmipServerCloseError
-from tests.fake_hmip_server import FakeLookupHmip, FakeConnectionHmip, FakeWebsocketHmip
-from tests.helpers import mockreturn
 
 
 @pytest.fixture

--- a/tests/aio_tests/test_async_device.py
+++ b/tests/aio_tests/test_async_device.py
@@ -1,86 +1,80 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
-from homematicip.aio.home import AsyncHome
-from homematicip.EventHook import EventHook
 from homematicip.aio.device import AsyncDevice, AsyncWallMountedThermostatPro
+from homematicip.aio.home import AsyncHome
 from homematicip.base.enums import *
-
-import json
-from datetime import datetime, timedelta, timezone
-from conftest import no_ssl_verification
-
 
 dt = datetime.now(timezone.utc).astimezone()
 utc_offset = dt.utcoffset() // timedelta(seconds=1)
 
 @pytest.mark.asyncio
-async def test_basic_device_functions(fake_async_home:AsyncHome):
-    with no_ssl_verification():
-        d = fake_async_home.search_device_by_id('3014F7110000000000000009')
-        assert d.label == "Brunnen"
-        assert d.routerModuleEnabled == True
+async def test_basic_device_functions(no_ssl_fake_async_home:AsyncHome):
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000009')
+    assert d.label == "Brunnen"
+    assert d.routerModuleEnabled is True
 
-        await d.set_label("new label")
-        await d.set_router_module_enabled(False)
-        await fake_async_home.get_current_state()
-        d = fake_async_home.search_device_by_id('3014F7110000000000000009')
-        assert d.label == "new label"
-        assert d.routerModuleEnabled == False
+    await d.set_label("new label")
+    await d.set_router_module_enabled(False)
+    await no_ssl_fake_async_home.get_current_state()
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000009')
+    assert d.label == "new label"
+    assert d.routerModuleEnabled is False
 
-        await d.set_label("other label")
-        await d.set_router_module_enabled(True)
-        await fake_async_home.get_current_state()
-        d = fake_async_home.search_device_by_id('3014F7110000000000000009')
-        assert d.label == "other label"
-        assert d.routerModuleEnabled == True
+    await d.set_label("other label")
+    await d.set_router_module_enabled(True)
+    await no_ssl_fake_async_home.get_current_state()
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000009')
+    assert d.label == "other label"
+    assert d.routerModuleEnabled is True
 
-        d2 = fake_async_home.search_device_by_id('3014F7110000000000000005')
-        await d.delete()
-        await fake_async_home.get_current_state()
-        d = fake_async_home.search_device_by_id('3014F7110000000000000009')
-        assert d == None
-        assert d2 is fake_async_home.search_device_by_id('3014F7110000000000000005') # make sure that the objects got updated and not completely renewed
+    d2 = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000005')
+    await d.delete()
+    await no_ssl_fake_async_home.get_current_state()
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000009')
+    assert d == None
+    assert d2 is no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000005') # make sure that the objects got updated and not completely renewed
 
 
 @pytest.mark.asyncio
-async def test_water_sensor(fake_async_home: AsyncHome):
-    with no_ssl_verification():
-        d = fake_async_home.search_device_by_id("3014F7110000000000000050")
-        assert d.label == "Wassersensor"
-        assert d.routerModuleEnabled == False
-        assert d.routerModuleSupported == False
+async def test_water_sensor(no_ssl_fake_async_home: AsyncHome):
+    d = no_ssl_fake_async_home.search_device_by_id("3014F7110000000000000050")
+    assert d.label == "Wassersensor"
+    assert d.routerModuleEnabled is False
+    assert d.routerModuleSupported is False
 
-        assert d.incorrectPositioned == True
-        assert d.acousticAlarmSignal == AcousticAlarmSignal.FREQUENCY_RISING
-        assert d.acousticAlarmTiming == AcousticAlarmTiming.ONCE_PER_MINUTE
-        assert d.acousticWaterAlarmTrigger == WaterAlarmTrigger.WATER_DETECTION
-        assert d.inAppWaterAlarmTrigger == WaterAlarmTrigger.WATER_MOISTURE_DETECTION
-        assert d.moistureDetected == False
-        assert d.sirenWaterAlarmTrigger == WaterAlarmTrigger.WATER_MOISTURE_DETECTION
-        assert d.waterlevelDetected == False
+    assert d.incorrectPositioned is True
+    assert d.acousticAlarmSignal == AcousticAlarmSignal.FREQUENCY_RISING
+    assert d.acousticAlarmTiming == AcousticAlarmTiming.ONCE_PER_MINUTE
+    assert d.acousticWaterAlarmTrigger == WaterAlarmTrigger.WATER_DETECTION
+    assert d.inAppWaterAlarmTrigger == WaterAlarmTrigger.WATER_MOISTURE_DETECTION
+    assert d.moistureDetected is False
+    assert d.sirenWaterAlarmTrigger == WaterAlarmTrigger.WATER_MOISTURE_DETECTION
+    assert d.waterlevelDetected is False
 
-        await d.set_acoustic_alarm_timing(AcousticAlarmTiming.SIX_MINUTES)
-        await d.set_acoustic_alarm_signal(AcousticAlarmSignal.FREQUENCY_ALTERNATING_LOW_HIGH)
-        await d.set_inapp_water_alarm_trigger(WaterAlarmTrigger.MOISTURE_DETECTION)
-        await d.set_acoustic_water_alarm_trigger(WaterAlarmTrigger.NO_ALARM)
-        await d.set_siren_water_alarm_trigger(WaterAlarmTrigger.NO_ALARM)
+    await d.set_acoustic_alarm_timing(AcousticAlarmTiming.SIX_MINUTES)
+    await d.set_acoustic_alarm_signal(AcousticAlarmSignal.FREQUENCY_ALTERNATING_LOW_HIGH)
+    await d.set_inapp_water_alarm_trigger(WaterAlarmTrigger.MOISTURE_DETECTION)
+    await d.set_acoustic_water_alarm_trigger(WaterAlarmTrigger.NO_ALARM)
+    await d.set_siren_water_alarm_trigger(WaterAlarmTrigger.NO_ALARM)
 
-        await fake_async_home.get_current_state()
-        d = fake_async_home.search_device_by_id("3014F7110000000000000050")
+    await no_ssl_fake_async_home.get_current_state()
+    d = no_ssl_fake_async_home.search_device_by_id("3014F7110000000000000050")
 
-        assert d.acousticAlarmTiming == AcousticAlarmTiming.SIX_MINUTES
-        assert d.acousticAlarmSignal == AcousticAlarmSignal.FREQUENCY_ALTERNATING_LOW_HIGH
-        assert d.acousticWaterAlarmTrigger == WaterAlarmTrigger.NO_ALARM
-        assert d.inAppWaterAlarmTrigger == WaterAlarmTrigger.MOISTURE_DETECTION
-        assert d.sirenWaterAlarmTrigger == WaterAlarmTrigger.NO_ALARM
+    assert d.acousticAlarmTiming == AcousticAlarmTiming.SIX_MINUTES
+    assert d.acousticAlarmSignal == AcousticAlarmSignal.FREQUENCY_ALTERNATING_LOW_HIGH
+    assert d.acousticWaterAlarmTrigger == WaterAlarmTrigger.NO_ALARM
+    assert d.inAppWaterAlarmTrigger == WaterAlarmTrigger.MOISTURE_DETECTION
+    assert d.sirenWaterAlarmTrigger == WaterAlarmTrigger.NO_ALARM
 
-def test_all_devices_implemented(fake_async_home:AsyncHome):
-    for d in fake_async_home.devices:
+def test_all_devices_implemented(no_ssl_fake_async_home:AsyncHome):
+    for d in no_ssl_fake_async_home.devices:
         assert type(d) != AsyncDevice
 
 @pytest.mark.asyncio
-async def test_wall_mounted_thermostat_pro(fake_async_home : AsyncHome ):
-    d = fake_async_home.search_device_by_id('3014F7110000000000000022')
+async def test_wall_mounted_thermostat_pro(no_ssl_fake_async_home : AsyncHome ):
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000022')
     assert isinstance(d, AsyncWallMountedThermostatPro)
     assert d.id == "3014F7110000000000000022"
     assert d.label == "Wandthermostat"
@@ -95,19 +89,18 @@ async def test_wall_mounted_thermostat_pro(fake_async_home : AsyncHome ):
     assert d.setPointTemperature == 5.0
     assert d.display == ClimateControlDisplay.ACTUAL_HUMIDITY
     assert d.temperatureOffset == 0.0
-    assert d.lowBat == False
-    assert d.operationLockActive == False
-    assert d.routerModuleEnabled == False
-    assert d.routerModuleSupported == False
+    assert d.lowBat is False
+    assert d.operationLockActive is False
+    assert d.routerModuleEnabled is False
+    assert d.routerModuleSupported is False
     assert d.rssiDeviceValue == -76
     assert d.rssiPeerValue == -63
-    assert d.unreach == False
-    assert d.dutyCycle == False
+    assert d.unreach is False
+    assert d.dutyCycle is False
     assert d.availableFirmwareVersion == "0.0.0"
     assert d.firmwareVersion == "1.8.0"
 
-    with no_ssl_verification():
-        await d.set_display( ClimateControlDisplay.ACTUAL)
-        await fake_async_home.get_current_state()
-        d = fake_async_home.search_device_by_id('3014F7110000000000000022')
-        assert d.display == ClimateControlDisplay.ACTUAL
+    await d.set_display( ClimateControlDisplay.ACTUAL)
+    await no_ssl_fake_async_home.get_current_state()
+    d = no_ssl_fake_async_home.search_device_by_id('3014F7110000000000000022')
+    assert d.display == ClimateControlDisplay.ACTUAL

--- a/tests/aio_tests/test_async_groups.py
+++ b/tests/aio_tests/test_async_groups.py
@@ -1,16 +1,11 @@
-import pytest
-
-from homematicip.aio.home import AsyncHome
-from homematicip.EventHook import EventHook
-from homematicip.aio.group import AsyncGroup
-import json
 from datetime import datetime, timedelta, timezone
-from conftest import no_ssl_verification
 
+from homematicip.aio.group import AsyncGroup
+from homematicip.aio.home import AsyncHome
 
 dt = datetime.now(timezone.utc).astimezone()
 utc_offset = dt.utcoffset() // timedelta(seconds=1)
 
-def test_all_groups_implemented(fake_async_home:AsyncHome):
-    for g in fake_async_home.groups:
+def test_all_groups_implemented(no_ssl_fake_async_home:AsyncHome):
+    for g in no_ssl_fake_async_home.groups:
         assert type(g) != AsyncGroup

--- a/tests/aio_tests/test_async_home.py
+++ b/tests/aio_tests/test_async_home.py
@@ -1,58 +1,53 @@
-import pytest
-
-from homematicip.aio.home import AsyncHome
-from homematicip.EventHook import EventHook
-from homematicip.base.enums import *
-import json
 from datetime import datetime, timedelta, timezone
+
+import pytest
 from conftest import fake_home_download_configuration, no_ssl_verification
 
+from homematicip.aio.home import AsyncHome
+from homematicip.base.enums import *
 
 dt = datetime.now(timezone.utc).astimezone()
 utc_offset = dt.utcoffset() // timedelta(seconds=1)
 
 @pytest.mark.asyncio
-async def test_async_home_base(fake_async_home: AsyncHome):
-    with no_ssl_verification():
-        assert fake_async_home.connected == True
-        assert fake_async_home.currentAPVersion == "1.2.4"
-        assert fake_async_home.deviceUpdateStrategy == DeviceUpdateStrategy.AUTOMATICALLY_IF_POSSIBLE
-        assert fake_async_home.dutyCycle == 8.0
-        assert fake_async_home.pinAssigned == False
-        assert fake_async_home.powerMeterCurrency == "EUR"
-        assert fake_async_home.powerMeterUnitPrice == 0.0
-        assert fake_async_home.timeZoneId == "Europe/Vienna"
-        assert fake_async_home.updateState == HomeUpdateState.UP_TO_DATE
+async def test_async_home_base(no_ssl_fake_async_home: AsyncHome):
+    assert no_ssl_fake_async_home.connected == True
+    assert no_ssl_fake_async_home.currentAPVersion == "1.2.4"
+    assert no_ssl_fake_async_home.deviceUpdateStrategy == DeviceUpdateStrategy.AUTOMATICALLY_IF_POSSIBLE
+    assert no_ssl_fake_async_home.dutyCycle == 8.0
+    assert no_ssl_fake_async_home.pinAssigned == False
+    assert no_ssl_fake_async_home.powerMeterCurrency == "EUR"
+    assert no_ssl_fake_async_home.powerMeterUnitPrice == 0.0
+    assert no_ssl_fake_async_home.timeZoneId == "Europe/Vienna"
+    assert no_ssl_fake_async_home.updateState == HomeUpdateState.UP_TO_DATE
 
 @pytest.mark.asyncio
-async def test_home_location(fake_async_home: AsyncHome):
-    assert fake_async_home.location.city == "1010  Wien, Österreich"
-    assert fake_async_home.location.latitude == "48.208088"
-    assert fake_async_home.location.longitude == "16.358608"
-    assert fake_async_home.location._rawJSONData == fake_home_download_configuration()["home"]["location"]
-    assert str(fake_async_home.location) == "city(1010  Wien, Österreich) latitude(48.208088) longitude(16.358608)"
+async def test_home_location(no_ssl_fake_async_home: AsyncHome):
+    assert no_ssl_fake_async_home.location.city == "1010  Wien, Österreich"
+    assert no_ssl_fake_async_home.location.latitude == "48.208088"
+    assert no_ssl_fake_async_home.location.longitude == "16.358608"
+    assert no_ssl_fake_async_home.location._rawJSONData == fake_home_download_configuration()["home"]["location"]
+    assert str(no_ssl_fake_async_home.location) == "city(1010  Wien, Österreich) latitude(48.208088) longitude(16.358608)"
 
 @pytest.mark.asyncio
-async def test_home_set_location(fake_async_home: AsyncHome):
-    with no_ssl_verification():
-        await fake_async_home.set_location("Berlin, Germany", "52.530644", "13.383068")
-        await fake_async_home.get_current_state()
-        assert fake_async_home.location.city == "Berlin, Germany"
-        assert fake_async_home.location.latitude == "52.530644"
-        assert fake_async_home.location.longitude == "13.383068"
-        assert str(fake_async_home.location) == "city(Berlin, Germany) latitude(52.530644) longitude(13.383068)"
+async def test_home_set_location(no_ssl_fake_async_home: AsyncHome):
+    await no_ssl_fake_async_home.set_location("Berlin, Germany", "52.530644", "13.383068")
+    await no_ssl_fake_async_home.get_current_state()
+    assert no_ssl_fake_async_home.location.city == "Berlin, Germany"
+    assert no_ssl_fake_async_home.location.latitude == "52.530644"
+    assert no_ssl_fake_async_home.location.longitude == "13.383068"
+    assert str(no_ssl_fake_async_home.location) == "city(Berlin, Germany) latitude(52.530644) longitude(13.383068)"
 
 
 @pytest.mark.asyncio
-async def test_security_zones_activation(fake_async_home: AsyncHome):
-    with no_ssl_verification():
-        internal, external = fake_async_home.get_security_zones_activation()
-        assert internal == False
-        assert external == False
+async def test_security_zones_activation(no_ssl_fake_async_home: AsyncHome):
+    internal, external = no_ssl_fake_async_home.get_security_zones_activation()
+    assert internal == False
+    assert external == False
 
-        await fake_async_home.set_security_zones_activation(True,True)
-        await fake_async_home.get_current_state()
+    await no_ssl_fake_async_home.set_security_zones_activation(True,True)
+    await no_ssl_fake_async_home.get_current_state()
 
-        internal, external = fake_async_home.get_security_zones_activation()
-        assert internal == True
-        assert external == True
+    internal, external = no_ssl_fake_async_home.get_security_zones_activation()
+    assert internal == True
+    assert external == True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,15 @@ from pathlib import Path
 import pytest
 import json
 
-from functools import partialmethod
+from functools import partialmethod, partial
 import warnings
 import requests
 import contextlib
 import aiohttp
 
 from unittest.mock import MagicMock
+
+from aio.auth import AsyncAuth
 from homematicip.aio.connection import AsyncConnection
 from homematicip.aio.home import AsyncHome
 from homematicip.home import Home
@@ -19,9 +21,7 @@ from pytest_localserver.http import WSGIServer
 from fake_cloud_server import FakeCloudServer
 
 
-def fake_home_download_configuration():
-    with open("tests/json_data/home.json", encoding="UTF-8") as f:
-        return json.load(f)
+
 
 def get_full_path(name):
     """Returns full path of incoming relative path.
@@ -30,76 +30,84 @@ def get_full_path(name):
     pth = Path(__file__).parent.joinpath(name)
     return pth
 
+def fake_home_download_configuration():
+    _full = get_full_path("json_data/home.json")
+    with open(_full, encoding="UTF-8") as f:
+        return json.load(f)
+
+
 @contextlib.contextmanager
 def no_ssl_verification():
     old_request = requests.Session.request
     requests.Session.request = partialmethod(old_request, verify=False)
-    
-    old_aiohttp_post = aiohttp.ClientSession.post
-    old_aiohttp_get = aiohttp.ClientSession.get
-    old_aiohttp_put = aiohttp.ClientSession.put
-    aiohttp.ClientSession.post = partialmethod(old_aiohttp_post,  ssl=False)
-    aiohttp.ClientSession.get = partialmethod(old_aiohttp_get,  ssl=False)
-    aiohttp.ClientSession.put = partialmethod(old_aiohttp_put,  ssl=False)
 
-
-    warnings.filterwarnings('ignore', 'Unverified HTTPS request')
+    warnings.filterwarnings("ignore", "Unverified HTTPS request")
     yield
     warnings.resetwarnings()
 
     requests.Session.request = old_request
-    aiohttp.ClientSession.post = old_aiohttp_post
-    aiohttp.ClientSession.get = old_aiohttp_get
-    aiohttp.ClientSession.put = old_aiohttp_put
-
 
 
 @pytest.fixture
 def fake_cloud(request):
     """Defines the testserver funcarg"""
     app = FakeCloudServer()
-    server = WSGIServer(application = app, ssl_context=(get_full_path("server.crt"),get_full_path("server.key")))
+    server = WSGIServer(
+        application=app,
+        ssl_context=(get_full_path("server.crt"), get_full_path("server.key")),
+    )
     app.url = server.url
     server.start()
     request.addfinalizer(server.stop)
     return server
+
 
 @pytest.fixture
 def fake_home(fake_cloud):
     home = Home()
     with no_ssl_verification():
         lookup_url = "{}/getHost".format(fake_cloud.url)
-    #    home.download_configuration = fake_home_download_configuration
+        #    home.download_configuration = fake_home_download_configuration
         home._connection = Connection()
         home._fake_cloud = fake_cloud
-        home.set_auth_token("8A45BAA53BE37E3FCA58E9976EFA4C497DAFE55DB997DB9FD685236E5E63ED7DE")
-        home._connection.init(accesspoint_id="3014F711A000000BAD0C0DED", lookup_url=lookup_url)
+        home.set_auth_token(
+            "8A45BAA53BE37E3FCA58E9976EFA4C497DAFE55DB997DB9FD685236E5E63ED7DE"
+        )
+        home._connection.init(
+            accesspoint_id="3014F711A000000BAD0C0DED", lookup_url=lookup_url
+        )
         home.get_current_state()
     return home
 
 
-#are these still needed?
-#@pytest.fixture
-#def fake_connection(event_loop):
-#    _connection = AsyncConnection(event_loop)
-#    _connection.api_call = AsyncMock(return_value='called')
-#    return _connection
+@pytest.fixture
+async def no_ssl_fake_async_home(fake_cloud, event_loop):
+    home = AsyncHome(event_loop)
+    home._connection._websession.post = partial(
+        home._connection._websession.post, ssl=False
+    )
 
-#@pytest.fixture
-#def async_connection(event_loop):
-#    _connection = AsyncConnection(event_loop)
-#    yield _connection
-#    _connection._websession.close()
+    lookup_url = "{}/getHost".format(fake_cloud.url)
+    home._fake_cloud = fake_cloud
+    home.set_auth_token(
+        "8A45BAA53BE37E3FCA58E9976EFA4C497DAFE55DB997DB9FD685236E5E63ED7DE"
+    )
+    await home._connection.init(
+        accesspoint_id="3014F711A000000BAD0C0DED", lookup_url=lookup_url
+    )
+    await home.get_current_state()
+
+    yield home
+
+    await home._connection._websession.close()
+
 
 @pytest.fixture
-async def fake_async_home(fake_cloud,event_loop):
-    home = AsyncHome(event_loop)
-    with no_ssl_verification():
-        lookup_url = "{}/getHost".format(fake_cloud.url)
-    #    home.download_configuration = fake_home_download_configuration
-        home._connection = AsyncConnection(event_loop)
-        home._fake_cloud = fake_cloud
-        home.set_auth_token("8A45BAA53BE37E3FCA58E9976EFA4C497DAFE55DB997DB9FD685236E5E63ED7DE")
-        await home._connection.init(accesspoint_id="3014F711A000000BAD0C0DED", lookup_url=lookup_url)
-        await home.get_current_state()
-    yield home
+async def no_ssl_fake_async_auth(event_loop):
+    auth = AsyncAuth(event_loop)
+    auth._connection._websession.post = partial(
+        auth._connection._websession.post, ssl=False
+    )
+    yield auth
+
+    await auth._connection._websession.close()


### PR DESCRIPTION
All async tests are okay now.

Somehow the context manager `no_ssl_verification` which wraps request calls in partials make python complain about unclosed sessions.

I removed the context manager and created separate fixtures for this.