### PR TITLE
fixed checking returned locale (tuple)

### DIFF
--- a/homematicip/base/base_connection.py
+++ b/homematicip/base/base_connection.py
@@ -42,7 +42,7 @@ class BaseConnection:
         }
         lang = "en_US"
         def_locale = locale.getdefaultlocale()
-        if def_locale != None:
+        if def_locale != None and def_locale[0] != None:
             lang = def_locale[0]
 
         self._clientCharacteristics = {


### PR DESCRIPTION
The returned default locale on a raspberry pi runing arch linux is a tuple (None, None) if no default locale is found. The None check thus doesnt work and assigns 'None' to the locale resulting in a crash.