### PR TITLE
webhook fix for GROUP_CHANGED event

### DIFF
--- a/homematicip/home.py
+++ b/homematicip/home.py
@@ -681,6 +681,9 @@ class Home(HomeMaticIPObject.HomeMaticIPObject):
                 if pushEventType == EventType.GROUP_CHANGED:
                     data = event["group"]
                     obj = self.search_group_by_id(data["id"])
+                    if obj is None:
+                        obj = self._parse_group(data)
+                        self.groups.append(obj)
                     if type(obj) is MetaGroup:
                         obj.from_json(data, self.devices, self.groups)
                     else:


### PR DESCRIPTION
The webhook error handler `_ws_on_message` crashes if the `search_group_by_id` method returns `None`. Changed the handling of the returned object similar to the `DEVICE_CHANGED` event