### PR TITLE
Refactor get_current_state

### DIFF
--- a/homematicip/aio/home.py
+++ b/homematicip/aio/home.py
@@ -29,6 +29,12 @@ class AsyncHome(Home):
         await self._connection.init(access_point_id, lookup)
 
     async def get_current_state(self, clearConfig: bool = False):
+        """downloads the current configuration and parses it into self
+
+        Args:
+            clearConfig(bool): if set to true, this function will remove all old objects
+            from self.devices, self.client, ... to have a fresh config instead of reparsing them
+        """
         json_state = await self.download_configuration()
         return self.update_home(json_state, clearConfig)
 

--- a/homematicip/aio/home.py
+++ b/homematicip/aio/home.py
@@ -29,36 +29,8 @@ class AsyncHome(Home):
         await self._connection.init(access_point_id, lookup)
 
     async def get_current_state(self, clearConfig: bool = False):
-        # todo: a download_configuration method has been added. This can simplify this one.
-        json_state = await self._connection.api_call(
-            "home/getCurrentState", json.dumps(self._connection.clientCharacteristics)
-        )
-        if "errorCode" in json_state:
-            LOGGER.error(
-                "Could not get the current configuration. Error: %s",
-                json_state["errorCode"],
-            )
-            return False
-
-        if clearConfig:
-            self.devices = []
-            self.clients = []
-            self.groups = []
-            self.rules = []
-            self.functionalHomes = []
-
-        js_home = json_state["home"]
-
-        self.from_json(js_home)
-
-        self._get_devices(json_state)
-        self._get_clients(json_state)
-        self._get_groups(json_state)
-
-        self._get_functionalHomes(js_home)
-        self._load_functionalChannels()
-
-        return True
+        json_state = await self.download_configuration()
+        return self.update_home(json_state, clearConfig)
 
     async def download_configuration(self):
         return await self._connection.api_call(*super().download_configuration())

--- a/homematicip/home.py
+++ b/homematicip/home.py
@@ -243,6 +243,13 @@ class Home(HomeMaticIPObject.HomeMaticIPObject):
         return self.update_home(json_state, clearConfig)
 
     def update_home(self, json_state, clearConfig: bool = False):
+        """parse a given json configuration into self.
+        This will update the whole home including devices, clients and groups.
+
+        Args:
+            clearConfig(bool): if set to true, this function will remove all old objects
+            from self.devices, self.client, ... to have a fresh config instead of reparsing them
+        """
         if "errorCode" in json_state:
             LOGGER.error(
                 "Could not get the current configuration. Error: %s",
@@ -264,6 +271,13 @@ class Home(HomeMaticIPObject.HomeMaticIPObject):
         return self.update_home_only(js_home, clearConfig)
 
     def update_home_only(self, js_home, clearConfig: bool = False):
+        """parse a given home json configuration into self.
+        This will update only the home without updating devices, clients and groups.
+
+        Args:
+            clearConfig(bool): if set to true, this function will remove all old objects
+            from self.devices, self.client, ... to have a fresh config instead of reparsing them
+        """
         if "errorCode" in js_home:
             LOGGER.error(
                 "Could not get the current configuration. Error: %s",

--- a/homematicip/home.py
+++ b/homematicip/home.py
@@ -240,7 +240,9 @@ class Home(HomeMaticIPObject.HomeMaticIPObject):
             from self.devices, self.client, ... to have a fresh config instead of reparsing them
         """
         json_state = self.download_configuration()
+        return self.update_home(json_state, clearConfig)
 
+    def update_home(self, json_state, clearConfig: bool = False):
         if "errorCode" in json_state:
             LOGGER.error(
                 "Could not get the current configuration. Error: %s",
@@ -252,17 +254,28 @@ class Home(HomeMaticIPObject.HomeMaticIPObject):
             self.devices = []
             self.clients = []
             self.groups = []
-            self.rules = []
-            self.functionalHomes = []
-
-        js_home = json_state["home"]
-
-        self.from_json(js_home)
 
         self._get_devices(json_state)
         self._get_clients(json_state)
         self._get_groups(json_state)
 
+        js_home = json_state["home"]
+
+        return self.update_home_only(js_home, clearConfig)
+
+    def update_home_only(self, js_home, clearConfig: bool = False):
+        if "errorCode" in js_home:
+            LOGGER.error(
+                "Could not get the current configuration. Error: %s",
+                js_home["errorCode"],
+            )
+            return False
+
+        if clearConfig:
+            self.rules = []
+            self.functionalHomes = []
+
+        self.from_json(js_home)
         self._get_functionalHomes(js_home)
         self._load_functionalChannels()
 


### PR DESCRIPTION
Hi,

i need a possibility to update home without downloading the configuration and without devices, groups and clients. Therefor i refactored update_home_only from  get_current_state.
Despite from that i tried to reuse code between AsyncHome and Home.

The functionality of get_current_state (Async/Sync) should be unchanged.

Is that OK for you?

BR
Markus