### PR TITLE
Import CancelledError from asyncio, not asyncio.futures

### DIFF
--- a/homematicip/aio/connection.py
+++ b/homematicip/aio/connection.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from asyncio.futures import CancelledError
+from asyncio import CancelledError
 from json.decoder import JSONDecodeError
 
 import aiohttp


### PR DESCRIPTION
It's no longer in .futures in Python 3.8.0.