### PR TITLE
Fix AsyncMotionDetectorPushButton

### DIFF
--- a/homematicip/aio/device.py
+++ b/homematicip/aio/device.py
@@ -285,7 +285,7 @@ class AsyncMotionDetectorOutdoor(MotionDetectorOutdoor, AsyncDevice):
     pass
 
 
-class AsyncMotionDetectorPushButton(MotionDetectorPushButton, AsyncSabotageDevice):
+class AsyncMotionDetectorPushButton(MotionDetectorPushButton, AsyncDevice):
     """ HMIP-SMI55 (Motion Detector with Brightness Sensor and Remote Control - 2-button) """
 
     pass


### PR DESCRIPTION
MotionDetectorPushButton does not support sabotage attribute.
This prevents 0.10.16 from updating in HA.