### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,10 @@ Homematic IP Devices:
 -  [X] HMIP-BWTH       (Wall Thermostat Display with switching output – for brand switches, 230V)
 -  [ ] HMIP-BWTH24     (Wall Thermostat Display with switching output – for brand switches, 24V)
 -  [ ] HMIP-DBB        (Doorbell Push-Button)
+-  [ ] HMIP-DRBLI4     (Blinds Actuator – 4x channels, 230V, 2,2A / 500W per channel) electrical DIN rail
+-  [ ] HMIP-DRSI1      (Actuator Inbound 230V – 1x channel) electrical DIN rail
+-  [ ] HMIP-DRDI3      (Dimming Actuator Inbound 230V – 3x channels, 200W per channel) electrical DIN rail
+-  [ ] HMIP-DRSI4      (Swich Actuator – 4x channels, 16A per channel) electrical DIN rail
 -  [ ] HMIP-DSD-PCB    (Door Signal Dector PCB) 
 -  [X] HMIP-eTRV       (Heating-Thermostat with Display)
 -  [X] HMIP-eTRV2      (Heating-Thermostat with Display) New Version


### PR DESCRIPTION
Alle HMIP-K-DR* sind Bausätze und gehen mit dem AP,  es wird diese als Nicht Baussätze geben diese heißen dann HMIP-DR*