### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/homematicip/aio/connection.py
+++ b/homematicip/aio/connection.py
@@ -83,7 +83,7 @@ class AsyncConnection(BaseConnection):
             path = self.full_url(path)
         for i in range(self._restCallRequestCounter):
             try:
-                with async_timeout.timeout(self._restCallTimout, loop=self._loop):
+                with async_timeout.timeout(self._restCallTimout):
                     result = await self._websession.post(
                         path, data=body, headers=self.headers
                     )


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed