### PR TITLE
Fix websocket connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,23 +226,27 @@ It’s also possible to use push notifications based on a websocket connection:
 
 .. code:: python
 
-    ##initialize the api
-    #...
-    #get the home object
-    home = homematicip.Home()
-    #add a function to handle new events
-    home.onEvent += printEvents
-    #enable the event connection -> this will also start the websocket connection to the homeMaticIP Cloud
+    # Example function to display incoming events.
+    def print_events(event_list):
+        for event in event_list:
+            print("EventType: {} Data: {}".format(event["eventType"], event["data"]))
+
+
+    # Initialise the API.
+    config = homematicip.find_and_load_config_file()
+    home = Home()
+    home.set_auth_token(config.auth_token)
+    home.init(config.access_point)
+
+    # Add function to handle events and start the connection.
+    home.onEvent += print_events
     home.enable_events()
 
-
-    #example function to display incoming events
-    def printEvents(eventList):
-        for event in eventList:
-            print "EventType: {} Data: {}".format(event["eventType"], event["data"])
-
-    #if needed you can close the websocket connection with
-    home.disable_events()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Interrupt.")
 
 .. |CircleCI| image:: https://circleci.com/gh/coreGreenberet/homematicip-rest-api.svg?style=shield
    :target: https://circleci.com/gh/coreGreenberet/homematicip-rest-api

--- a/homematicip/home.py
+++ b/homematicip/home.py
@@ -735,8 +735,8 @@ class Home(HomeMaticIPObject):
         data = {"deviceId": deviceId}
         return self._restCall("home/startInclusionModeForDevice", body=json.dumps(data))
 
-    def enable_events(self):
-        websocket.enableTrace(True)
+    def enable_events(self, enable_trace=False, ping_interval=20):
+        websocket.enableTrace(enable_trace)
 
         self.__webSocket = websocket.WebSocketApp(
             self._connection.urlWebSocket,
@@ -749,7 +749,7 @@ class Home(HomeMaticIPObject):
             on_close=self._ws_on_close,
         )
 
-        websocket_kwargs = {"ping_interval": 3}
+        websocket_kwargs = {"ping_interval": ping_interval}
         if hasattr(sys, "_called_from_test"):  # disable ssl during a test run
             sslopt = {"cert_reqs": ssl.CERT_NONE}
             websocket_kwargs = {"sslopt": sslopt, "ping_interval": 2, "ping_timeout": 1}
@@ -759,7 +759,7 @@ class Home(HomeMaticIPObject):
             target=self.__webSocket.run_forever,
             kwargs=websocket_kwargs,
         )
-        self.__webSocketThread.setDaemon(True)
+        self.__webSocketThread.daemon = True
         self.__webSocketThread.start()
 
     def disable_events(self):

--- a/homematicip/home.py
+++ b/homematicip/home.py
@@ -767,10 +767,10 @@ class Home(HomeMaticIPObject):
             self.__webSocket.close()
             self.__webSocket = None
 
-    def _ws_on_close(self):
+    def _ws_on_close(self, *_):
         self.__webSocket = None
 
-    def _ws_on_error(self, err):
+    def _ws_on_error(self, _, err):
         LOGGER.exception(err)
         self.onWsError.fire(err)
         if self.websocket_reconnect_on_error:
@@ -778,7 +778,7 @@ class Home(HomeMaticIPObject):
             self.disable_events()
             self.enable_events()
 
-    def _ws_on_message(self, message):
+    def _ws_on_message(self, _, message):
         # json.loads doesn't support bytes as parameter before python 3.6
         js = json.loads(bytes2str(message))
         # LOGGER.debug(js)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.24.0
-websocket-client>=0.57.0
+websocket-client>=1.0.0
 async_timeout>=3.0.1
 websockets>=8.1
 aiohttp>=3.6.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 requests==2.25.1
-websocket-client==0.57.0
+websocket-client==1.0.0
 async_timeout==3.0.1
 websockets==9.1
 aiohttp==3.7.4

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     install_requires=[
         "requests>=2.24.0",
-        "websocket-client>=0.57.0",
+        "websocket-client>=1.0.0",
         "websockets>=8.1",
         "aiohttp>=3.6.2",
         "async_timeout>=3.0.1",


### PR DESCRIPTION
Since websocket-client v0.58.0, callback functions require multiple arguments (see [websocket-client#669](https://github.com/websocket-client/websocket-client/issues/669)). As setup.py states version `websocket-client>=0.57.0` is required, newer versions will be automatically used on new installations and websocket events will result in the following exceptions:

```
TypeError: _ws_on_message() takes 2 positional arguments but 3 were given
...
TypeError: _ws_on_error() takes 2 positional arguments but 3 were given
```

This pull request fixes those errors by adding the required arguments to the callback functions. The minimal required version of websocket-client is increased to 1.0.0, which the author of that package created to indicate the breaking changes.

In addition, the following changes are made:

- The websocket example in the README is fixed. It was still Python2 code.
- Optional arguments are added to the enable_events method to be able to set the ping interval and disable the websocket trace.
- The deprecated setDaemon method call is replaced.