### PR TITLE
Do not pass loop for Py3.10 compat

### DIFF
--- a/homematicip/aio/connection.py
+++ b/homematicip/aio/connection.py
@@ -31,7 +31,7 @@ class AsyncConnection(BaseConnection):
         super().__init__()
         self._loop = loop
         if session is None:
-            self._websession = aiohttp.ClientSession(loop=loop)
+            self._websession = aiohttp.ClientSession()
         else:
             self._websession = session
         self.socket_connection = None  # ClientWebSocketResponse
@@ -117,7 +117,6 @@ class AsyncConnection(BaseConnection):
                     },
                 ),
                 timeout=self.connect_timeout,
-                loop=self._loop,
             )
         except asyncio.TimeoutError:
             raise HmipConnectionError("Connecting to hmip ws socket timed out.")


### PR DESCRIPTION
This makes this package compatible with Python 3.10.

Python 3.10 removes support for the `loop` parameter in asyncio methods. For background on this issue, see [this StackOverflow answer](https://stackoverflow.com/a/60315290)